### PR TITLE
test: Fix prepare cross-build failing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,12 +16,11 @@ on:
       - synchronize
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
+  melodic:
+    runs-on: ubuntu-18.04
     continue-on-error: true
     strategy:
       matrix:
-        ros-distro: [melodic]
         arch: [amd64, arm64, armhf]
     steps:
       - uses: actions/checkout@v2
@@ -32,12 +31,13 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: 'ros/ros_tutorials'
-          ref: '${{ matrix.ros-distro }}-devel'
+          ref: 'melodic-devel'
           path: 'ros_tutorials'
 
       - name: Prepare for Cross-Build
         if: contains(matrix.arch, 'arm') == true
         run: |
+          sudo apt-get update
           sudo apt-get install -y qemu-user-static
 
       - name: Prepare Docker
@@ -54,7 +54,7 @@ jobs:
           ${GITHUB_WORKSPACE}/run.sh "cd rospy_tutorials && /release_binary.sh"
           echo ::set-output name=paths::$(ls rospy_tutorials/release/*.deb)
         env:
-          ROS_DISTRO: ${{ matrix.ros-distro }}
+          ROS_DISTRO: melodic
           ARCH: ${{ matrix.arch }}
 
       - name: Output binary name


### PR DESCRIPTION
related: https://github.com/Tiryoh/docker_ros2/pull/11


https://github.com/Tiryoh/ros-release-tools/runs/740673948?check_suite_focus=true

<details>

<summary>extract of the error log</summary>

```
Run sudo apt-get install -y qemu-user-static
Reading package lists...
Building dependency tree...
Reading state information...
E: Failed to fetch http://security.ubuntu.com/ubuntu/pool/universe/q/qemu/qemu-user-static_2.11+dfsg-1ubuntu7.23_amd64.deb  404  Not Found [IP: 13.66.189.214 80]
The following NEW packages will be installed:
E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
  qemu-user-static
0 upgraded, 1 newly installed, 0 to remove and 12 not upgraded.
Need to get 10.0 MB of archives.
After this operation, 101 MB of additional disk space will be used.
Ign:1 http://azure.archive.ubuntu.com/ubuntu bionic-updates/universe amd64 qemu-user-static amd64 1:2.11+dfsg-1ubuntu7.23
Err:1 http://security.ubuntu.com/ubuntu bionic-updates/universe amd64 qemu-user-static amd64 1:2.11+dfsg-1ubuntu7.23
  404  Not Found [IP: 13.66.189.214 80]
##[error]Process completed with exit code 100.
```

</details>

The error on bloom-generate(#9) will be fixed in another PR.